### PR TITLE
Potential fix for code scanning alert no. 6: URL redirection from remote source

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,13 @@ def check_login():
 @app.route("/login")
 def login():
 	if session.get("logged_in"):
-		return redirect(request.referrer or url_for("index"))
+		referrer = request.referrer
+		if referrer:
+			from urllib.parse import urlparse
+			parsed_url = urlparse(referrer)
+			if parsed_url.netloc == request.host:
+				return redirect(referrer)
+		return redirect(url_for("index"))
 	return render_template("login.html", user="User", auth="/authenticate")
 
 @app.route("/authenticate", methods=["POST"])


### PR DESCRIPTION
Potential fix for [https://github.com/SASTRA-Projects/SASTRA/security/code-scanning/6](https://github.com/SASTRA-Projects/SASTRA/security/code-scanning/6)

To fix the problem, we need to validate the `request.referrer` before using it in a redirect. One way to do this is to ensure that the `referrer` is within the same host or a list of allowed hosts. We can use the `urlparse` function from the Python standard library to parse the URL and check the `netloc` attribute. If the `referrer` is not valid, we should redirect to a safe default URL, such as the home page.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
