### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -8,6 +8,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   check-flask-site:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SASTRA-Projects/SASTRA/security/code-scanning/19](https://github.com/SASTRA-Projects/SASTRA/security/code-scanning/19)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimum permissions required for the workflow to function. Based on the current workflow, it only needs to read repository contents (`contents: read`) to perform its tasks. No write permissions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
